### PR TITLE
Bkoz dev

### DIFF
--- a/gitops/base/deployment.yaml
+++ b/gitops/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: triton-server
-          image: nvcr.io/nvidia/tritonserver:25.04-pyt-python-py3
+          image: nvcr.io/nvidia/tritonserver:25.04-py3
           imagePullPolicy: IfNotPresent
           ports:
             - name: api

--- a/gitops/base/deployment.yaml
+++ b/gitops/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: triton-server
-          image: triton-server:latest
+          image: nvcr.io/nvidia/tritonserver:25.04-pyt-python-py3
           imagePullPolicy: IfNotPresent
           ports:
             - name: api

--- a/gitops/base/route.yaml
+++ b/gitops/base/route.yaml
@@ -18,3 +18,23 @@ spec:
     name: triton-server
     weight: 100
   wildcardPolicy: None
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: triton-server-metrics
+  labels:
+    deployment: triton-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  port:
+    targetPort: 8002
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: triton-server
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
NVIDIA moved the Triton Server image to ngc.io and split out the various backends. I updated this deployment to use the PyTorch, TensorRT, ONNX and OpenVINO backends. Also added a route for metrics.